### PR TITLE
Fix problem when acpi says "Not charging"

### DIFF
--- a/batteryarc-widget/batteryarc.lua
+++ b/batteryarc-widget/batteryarc.lua
@@ -89,7 +89,7 @@ local function worker(user_args)
         local charge = 0
         local status
         for s in stdout:gmatch("[^\r\n]+") do
-            local cur_status, charge_str, _ = string.match(s, '.+: (%a+), (%d?%d?%d)%%,?(.*)')
+            local cur_status, charge_str, _ = string.match(s, '.+: ([%a ]+), (%d?%d?%d)%%,?(.*)')
             if cur_status ~= nil and charge_str ~=nil then
                 local cur_charge = tonumber(charge_str)
                 if cur_charge > charge then


### PR DESCRIPTION
Notice the space between Not and charging.
By adding a space into the character set, we can now match the situation where the battery isn't charging or discharging.